### PR TITLE
[Untested draft] Compatibility with offline players

### DIFF
--- a/src/main/java/com/technicjelle/bluemapplayercontrol/commands/BMPC.java
+++ b/src/main/java/com/technicjelle/bluemapplayercontrol/commands/BMPC.java
@@ -2,6 +2,7 @@ package com.technicjelle.bluemapplayercontrol.commands;
 
 import de.bluecolored.bluemap.api.BlueMapAPI;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -10,8 +11,12 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class BMPC implements CommandExecutor, TabCompleter {
+
+	private List<String> playerNames;
+	private long cacheAge;
 
 	public BMPC() {
 	}
@@ -43,8 +48,10 @@ public class BMPC implements CommandExecutor, TabCompleter {
 			}
 
 			// === OTHER ===
-			Player targetPlayer = sender.getServer().getPlayer(args[args.length - 1]); //if the last argument is a player name
-			if (targetPlayer == null) {
+			//Suppressing deprecation warnings for Server::getOfflinePlayer(String), because we are only using the Name to look up the UUID, not as a unique identifier
+			@SuppressWarnings("deprecation")
+			OfflinePlayer targetPlayer = sender.getServer().getOfflinePlayer(args[args.length - 1]); //if the last argument is a player name
+			if (!targetPlayer.hasPlayedBefore()) { //targetPlayer can't be null so this is the easiest way to verify that a player with the given name actually exists
 				if(othersAllowed(sender)) {
 					sender.sendMessage(ChatColor.YELLOW + "Player not found");
 				} else {
@@ -53,6 +60,10 @@ public class BMPC implements CommandExecutor, TabCompleter {
 				return true;
 			} else {
 				if(othersAllowed(sender)) {
+					String displayName = targetPlayer.getName();
+					Player onlinePlayer = targetPlayer.getPlayer();
+					if(onlinePlayer != null)
+						displayName = onlinePlayer.getDisplayName();
 					UUID targetUUID = targetPlayer.getUniqueId();
 					if (args.length == 1) {
 						//TODO: Toggle other
@@ -60,11 +71,11 @@ public class BMPC implements CommandExecutor, TabCompleter {
 						return true;
 					} else if (args[0].equalsIgnoreCase("show")) {
 						api.getWebApp().setPlayerVisibility(targetUUID, true);
-						sender.sendMessage(targetPlayer.getDisplayName() + " is now visible on the map");
+						sender.sendMessage(displayName + " is now visible on the map");
 						return true;
 					} else if (args[0].equalsIgnoreCase("hide")) {
 						api.getWebApp().setPlayerVisibility(targetUUID, false);
-						sender.sendMessage(targetPlayer.getDisplayName() + " is now invisible on the map");
+						sender.sendMessage(displayName + " is now invisible on the map");
 						return true;
 					}
 				} else {
@@ -94,9 +105,15 @@ public class BMPC implements CommandExecutor, TabCompleter {
 					|| args[0].equalsIgnoreCase("hide")
 					|| args[0].isBlank()) {
 				if(args.length <= 2) {
-					for (Player player : sender.getServer().getOnlinePlayers()) {
-						completions.add(player.getName());
+					if(playerNames == null|| cacheAge < System.currentTimeMillis() - 60000){
+						playerNames = Arrays.stream(sender.getServer().getOfflinePlayers())
+								.map(OfflinePlayer::getName)
+								.collect(Collectors.toList());
+						cacheAge = System.currentTimeMillis();
 					}
+					completions.addAll(playerNames.stream()
+							.filter(name -> name.toLowerCase().startsWith(args[args.length - 1].toLowerCase()))
+							.collect(Collectors.toList()));
 				}
 			}
 		}


### PR DESCRIPTION
Just a quick draft because I had nothing better to do for about 15 mins :D I didn't put too much effort into this so feel free to reject it if you had something else in mind for this feature.

- Uses OfflinePlayer instead of Player, accepting all player names that have already played on the server
- Uses Player::getDisplayName instead of OfflinePlayer::getName if the player happens to be online
- Adds offline player names to tab completions and caches names for one minute (otherwise, each letter typed by the command sender would invoke IO calls on the player data directory and files)
- Filters the names in tab completions to only contain the ones that start with whatever the user already typed (case-insensitive), making it easier to search through the potentially huge list of names